### PR TITLE
Use the built-in English analyzer for everything

### DIFF
--- a/config/index.json
+++ b/config/index.json
@@ -1,0 +1,9 @@
+{
+    "analysis": {
+        "analyzer": {
+            "default": {
+                "type": "english"
+            }
+        }
+    }
+}

--- a/tasks/elasticsearch.rake
+++ b/tasks/elasticsearch.rake
@@ -17,6 +17,16 @@ namespace :elasticsearch do
     index = "oversight"
     index_url = "#{host}/#{index}"
 
+    if force
+      command = "curl -XDELETE '#{index_url}'"
+      puts "running: #{command}"
+      system command
+      puts
+
+      puts "Deleted index"
+      puts
+    end
+
     command = "curl -XPUT '#{index_url}'"
     puts "running: #{command}"
     system command
@@ -25,17 +35,31 @@ namespace :elasticsearch do
     puts "Ensured index exists"
     puts
 
+    command = "curl -XPOST '#{index_url}/_close'"
+    puts "running: #{command}"
+    system command
+    puts
+
+    puts "Closed index"
+    puts
+
+    command = "curl -XPUT '#{index_url}/_settings' -d @config/index.json"
+    puts "running: #{command}"
+    system command
+    puts
+
+    puts "Configured index"
+    puts
+
+    command = "curl -XPOST '#{index_url}/_open'"
+    puts "running: #{command}"
+    system command
+    puts
+
+    puts "Opened index"
+    puts
+
     mappings.each do |mapping|
-      if force
-        command = "curl -XDELETE '#{index_url}/_mapping/#{mapping}/'"
-        puts "running: #{command}"
-        system command
-        puts
-
-        puts "Deleted #{mapping}"
-        puts
-      end
-
       command = "curl -XPUT '#{index_url}/_mapping/#{mapping}' -d @config/mappings/#{mapping}.json"
       puts "running: #{command}"
       system command


### PR DESCRIPTION
This PR configures the elasticsearch index to use the "english" analyzer. (See https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-lang-analyzer.html#english-analyzer) This provides reasonable defaults for a number of things, including tokenization, stemming, (#22) and "stop words." Changes will only take effect after running the rake init task. I also changed the force option in the init task to delete the whole index, not just the mapping, now that there is index-level configuration. I have not yet investigated what happens if you change the analyzer on an index that already has documents.