### PR TITLE
Mapping changes

### DIFF
--- a/config/mappings/reports.json
+++ b/config/mappings/reports.json
@@ -9,6 +9,9 @@
         "type": "string",
         "term_vector": "with_positions_offsets"
       },
+      "title": {
+        "type": "string"
+      },
       "agency": {
         "type": "string",
         "index": "not_analyzed"
@@ -21,9 +24,15 @@
         "type": "string",
         "index": "not_analyzed"
       },
+      "source": {
+        "type": "string"
+      },
       "inspector": {
         "type": "string",
         "index": "not_analyzed"
+      },
+      "topic": {
+        "type": "string"
       },
       "inspector_url": {
         "type": "string",
@@ -33,6 +42,12 @@
         "type": "string",
         "index": "not_analyzed"
       },
+      "year": {
+        "type": "long"
+      },
+      "estimated_date": {
+        "type": "boolean"
+      },
       "report_id": {
         "type": "string",
         "index": "not_analyzed"
@@ -40,6 +55,42 @@
       "type": {
         "type": "string",
         "index": "not_analyzed"
+      },
+      "landing_url": {
+        "type": "string"
+      },
+      "url": {
+        "type": "string"
+      },
+      "text_url": {
+        "type": "string"
+      },
+      "unreleased": {
+        "type": "boolean"
+      },
+      "pdf": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "creation_date": {
+            "type": "date",
+            "format": "dateOptionalTime"
+          },
+          "keywords": {
+            "type": "string"
+          },
+          "modification_date": {
+            "type": "date",
+            "format": "dateOptionalTime"
+          },
+          "page_count": {
+            "type": "long"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     }
   }

--- a/config/mappings/reports.json
+++ b/config/mappings/reports.json
@@ -39,8 +39,8 @@
         "index": "not_analyzed"
       },
       "published_on": {
-        "type": "string",
-        "index": "not_analyzed"
+        "type": "date",
+        "format": "dateOptionalTime"
       },
       "year": {
         "type": "long"

--- a/config/mappings/reports.json
+++ b/config/mappings/reports.json
@@ -25,7 +25,8 @@
         "index": "not_analyzed"
       },
       "source": {
-        "type": "string"
+        "type": "string",
+        "index": "not_analyzed"
       },
       "inspector": {
         "type": "string",
@@ -57,13 +58,16 @@
         "index": "not_analyzed"
       },
       "landing_url": {
-        "type": "string"
+        "type": "string",
+        "index": "not_analyzed"
       },
       "url": {
-        "type": "string"
+        "type": "string",
+        "index": "not_analyzed"
       },
       "text_url": {
-        "type": "string"
+        "type": "string",
+        "index": "not_analyzed"
       },
       "unreleased": {
         "type": "boolean"

--- a/config/mappings/reports.json
+++ b/config/mappings/reports.json
@@ -41,7 +41,7 @@
       },
       "published_on": {
         "type": "date",
-        "format": "dateOptionalTime"
+        "format": "date"
       },
       "year": {
         "type": "short"
@@ -79,14 +79,14 @@
           },
           "creation_date": {
             "type": "date",
-            "format": "dateOptionalTime"
+            "format": "date"
           },
           "keywords": {
             "type": "string"
           },
           "modification_date": {
             "type": "date",
-            "format": "dateOptionalTime"
+            "format": "date"
           },
           "page_count": {
             "type": "short"

--- a/config/mappings/reports.json
+++ b/config/mappings/reports.json
@@ -44,7 +44,7 @@
         "format": "dateOptionalTime"
       },
       "year": {
-        "type": "long"
+        "type": "short"
       },
       "estimated_date": {
         "type": "boolean"
@@ -89,7 +89,7 @@
             "format": "dateOptionalTime"
           },
           "page_count": {
-            "type": "long"
+            "type": "short"
           },
           "title": {
             "type": "string"

--- a/config/mappings/reports.json
+++ b/config/mappings/reports.json
@@ -47,7 +47,8 @@
         "type": "short"
       },
       "estimated_date": {
-        "type": "boolean"
+        "type": "boolean",
+        "null_value": false
       },
       "report_id": {
         "type": "string",
@@ -70,7 +71,8 @@
         "index": "not_analyzed"
       },
       "unreleased": {
-        "type": "boolean"
+        "type": "boolean",
+        "null_value": false
       },
       "pdf": {
         "properties": {


### PR DESCRIPTION
When adding documents to the index, several properties get created dynamically. This PR explicitly adds those properties when creating the mapping, and reconfigures data type and indexing/analysis settings. Date fields are now handled as date type, not string, and URLs no longer go through the analyzer. I also shrunk the two long properties to shorts, and set default values on the two boolean properties.

Since this PR changes data types, deploying will require `rake elasticsearch:init force=true` and a reindex as well.