### PR TITLE
Change elasticsearch id to include inspector

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -47,7 +47,7 @@ module.exports = {
   },
 
   report: function(req, res) {
-    get(req.params.report_id).then(function(result) {
+    get(req.params.inspector, req.params.report_id).then(function(result) {
       res.render("report.html", {
         reportCount: reportCount,
         report: result._source
@@ -63,11 +63,11 @@ module.exports = {
 
 };
 
-function get(id) {
+function get(inspector, report_id) {
   return es.get({
     index: 'oversight',
     type: 'reports',
-    id: id
+    id: inspector + '-' + report_id
   });
 }
 

--- a/tasks/inspectors.js
+++ b/tasks/inspectors.js
@@ -99,7 +99,7 @@ function run(options) {
     es.index({
       index: 'oversight',
       type: 'reports',
-      id: report_id,
+      id: inspector + '-' + report_id,
       body: data
     }, function(err) {
       if (err) {


### PR DESCRIPTION
This changes the ID used to look up single reports to be of the format "inspector"-"report_id". The indexing script is changed to match.

This fixes #5

(Deploying this change will require re-indexing the reports)