### PR TITLE
Lint ejs templates

### DIFF
--- a/node_modules/intercept-stdout/.gitattributes
+++ b/node_modules/intercept-stdout/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/node_modules/intercept-stdout/.npmignore
+++ b/node_modules/intercept-stdout/.npmignore
@@ -1,0 +1,1 @@
+*node_modules*

--- a/node_modules/intercept-stdout/LICENSE
+++ b/node_modules/intercept-stdout/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Steve Farthing
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/intercept-stdout/README.md
+++ b/node_modules/intercept-stdout/README.md
@@ -1,0 +1,51 @@
+# Node.js Intercept stdout
+
+> intercept-stdout captures or modifies stdout and/or stderr.
+
+> _<sup>Based on [this](https://gist.github.com/benbuckman/2758563) gist</sup>_
+
+## Capture
+```javascript
+var intercept = require("intercept-stdout"),
+	captured_text = "";
+
+var unhook_intercept = intercept(function(txt) {
+	captured_text += txt;
+});
+
+console.log("This text is being captured");
+
+// Let's stop capturing stdout.
+unhook_intercept();
+
+console.log("This text is not being captured");
+```
+
+## Modify
+```javascript
+var intercept = require("intercept-stdout");
+
+var unhook_intercept = intercept(function(txt) {
+	return txt.replace( /this/i , 'that' );
+});
+
+console.log("This text is being modified");
+// -> that text is being modified
+```
+
+## Test
+
+	npm install
+	npm test
+
+## Separating Error Text
+
+Starting in Version 0.1.2, you may now specify two interceptor callbacks. If a second interceptor callback is specified, the second callback will be invoked for `stderr` output.
+
+## Errors and Warnings
+
+Versions > 0.1.1 hook both `stdout` and `stderr`. This change enables capturing of `console.log`, `console.info`, `console.warn`, and `console.error`. This change may break pre-existing interceptors if your interceptor expected output to be a full line of text.
+
+## About Colorization
+
+Popular modules such as [`mocha`](http://mochajs.org/) and [`winston`](https://github.com/winstonjs/winston) may colorize output by inserting ANSI escape codes into the output stream. Both `mocha` and `winston` make multiple calls to the output streams while colorizing a line -- in order to be robust, your code should anticipate and deal with this.

--- a/node_modules/intercept-stdout/intercept-stdout.js
+++ b/node_modules/intercept-stdout/intercept-stdout.js
@@ -1,0 +1,53 @@
+// Borrowed.
+// https://gist.github.com/benbuckman/2758563
+
+
+var toArray	= require('lodash.toarray'),
+	util			= require('util');
+
+// Intercept stdout and stderr to pass output thru callback.
+//
+//  Optionally, takes two callbacks.
+//    If two callbacks are specified, 
+//      the first intercepts stdout, and
+//      the second intercepts stderr.
+//
+// returns an unhook() function, call when done intercepting
+module.exports = function (stdoutIntercept, stderrIntercept) {
+	stderrIntercept = stderrIntercept || stdoutIntercept;
+
+	var old_stdout_write = process.stdout.write;
+	var old_stderr_write = process.stderr.write;
+
+	process.stdout.write = (function(write) {
+		return function(string, encoding, fd) {
+			var args = toArray(arguments);
+			args[0] = interceptor( string, stdoutIntercept );
+			write.apply(process.stdout, args);
+		};
+	}(process.stdout.write));
+
+	process.stderr.write = (function(write) {
+		return function(string, encoding, fd) {
+			var args = toArray(arguments);
+			args[0] = interceptor( string, stderrIntercept );
+			write.apply(process.stderr, args);
+		};
+	}(process.stderr.write));
+
+	function interceptor(string, callback) {
+		// only intercept the string
+		var result = callback(string);
+		if (typeof result == 'string') {
+			string = result.replace( /\n$/ , '' ) + (result && (/\n$/).test( string ) ? '\n' : '');
+		}
+		return string;
+	}
+
+	// puts back to original
+	return function unhook() {
+		process.stdout.write = old_stdout_write;
+		process.stderr.write = old_stderr_write;
+	};
+
+};

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/LICENSE.txt
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/README.md
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/README.md
@@ -1,0 +1,20 @@
+# lodash.toarray v3.0.2
+
+The [modern build](https://github.com/lodash/lodash/wiki/Build-Differences) of [lodash’s](https://lodash.com/) `_.toArray` exported as a [Node.js](http://nodejs.org/)/[io.js](https://iojs.org/) module.
+
+## Installation
+
+Using npm:
+
+```bash
+$ {sudo -H} npm i -g npm
+$ npm i --save lodash.toarray
+```
+
+In Node.js/io.js:
+
+```js
+var toArray = require('lodash.toarray');
+```
+
+See the [documentation](https://lodash.com/docs#toArray) or [package source](https://github.com/lodash/lodash/blob/3.0.2-npm-packages/lodash.toarray) for more details.

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/index.js
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/index.js
@@ -1,0 +1,112 @@
+/**
+ * lodash 3.0.2 (Custom Build) <https://lodash.com/>
+ * Build: `lodash modern modularize exports="npm" -o ./`
+ * Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+ * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
+ * Copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ * Available under MIT license <https://lodash.com/license>
+ */
+var arrayCopy = require('lodash._arraycopy'),
+    baseValues = require('lodash._basevalues'),
+    keys = require('lodash.keys');
+
+/**
+ * Used as the [maximum length](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.max_safe_integer)
+ * of an array-like value.
+ */
+var MAX_SAFE_INTEGER = 9007199254740991;
+
+/**
+ * The base implementation of `_.property` without support for deep paths.
+ *
+ * @private
+ * @param {string} key The key of the property to get.
+ * @returns {Function} Returns the new function.
+ */
+function baseProperty(key) {
+  return function(object) {
+    return object == null ? undefined : object[key];
+  };
+}
+
+/**
+ * Gets the "length" property value of `object`.
+ *
+ * **Note:** This function is used to avoid a [JIT bug](https://bugs.webkit.org/show_bug.cgi?id=142792)
+ * that affects Safari on at least iOS 8.1-8.3 ARM64.
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @returns {*} Returns the "length" value.
+ */
+var getLength = baseProperty('length');
+
+/**
+ * Checks if `value` is a valid array-like length.
+ *
+ * **Note:** This function is based on [`ToLength`](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-tolength).
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a valid length, else `false`.
+ */
+function isLength(value) {
+  return typeof value == 'number' && value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER;
+}
+
+/**
+ * Converts `value` to an array.
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to convert.
+ * @returns {Array} Returns the converted array.
+ * @example
+ *
+ * (function() {
+ *   return _.toArray(arguments).slice(1);
+ * }(1, 2, 3));
+ * // => [2, 3]
+ */
+function toArray(value) {
+  var length = value ? getLength(value) : 0;
+  if (!isLength(length)) {
+    return values(value);
+  }
+  if (!length) {
+    return [];
+  }
+  return arrayCopy(value);
+}
+
+/**
+ * Creates an array of the own enumerable property values of `object`.
+ *
+ * **Note:** Non-object values are coerced to objects.
+ *
+ * @static
+ * @memberOf _
+ * @category Object
+ * @param {Object} object The object to query.
+ * @returns {Array} Returns the array of property values.
+ * @example
+ *
+ * function Foo() {
+ *   this.a = 1;
+ *   this.b = 2;
+ * }
+ *
+ * Foo.prototype.c = 3;
+ *
+ * _.values(new Foo);
+ * // => [1, 2] (iteration order is not guaranteed)
+ *
+ * _.values('hi');
+ * // => ['h', 'i']
+ */
+function values(object) {
+  return baseValues(object, keys(object));
+}
+
+module.exports = toArray;

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._arraycopy/LICENSE.txt
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._arraycopy/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js 1.7.0, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._arraycopy/README.md
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._arraycopy/README.md
@@ -1,0 +1,20 @@
+# lodash._arraycopy v3.0.0
+
+The [modern build](https://github.com/lodash/lodash/wiki/Build-Differences) of [lodash’s](https://lodash.com/) internal `arrayCopy` exported as a [Node.js](http://nodejs.org/)/[io.js](https://iojs.org/) module.
+
+## Installation
+
+Using npm:
+
+```bash
+$ {sudo -H} npm i -g npm
+$ npm i --save lodash._arraycopy
+```
+
+In Node.js/io.js:
+
+```js
+var arrayCopy = require('lodash._arraycopy');
+```
+
+See the [package source](https://github.com/lodash/lodash/blob/3.0.0-npm-packages/lodash._arraycopy) for more details.

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._arraycopy/index.js
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._arraycopy/index.js
@@ -1,0 +1,29 @@
+/**
+ * lodash 3.0.0 (Custom Build) <https://lodash.com/>
+ * Build: `lodash modern modularize exports="npm" -o ./`
+ * Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+ * Based on Underscore.js 1.7.0 <http://underscorejs.org/LICENSE>
+ * Copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ * Available under MIT license <https://lodash.com/license>
+ */
+
+/**
+ * Copies the values of `source` to `array`.
+ *
+ * @private
+ * @param {Array} source The array to copy values from.
+ * @param {Array} [array=[]] The array to copy values to.
+ * @returns {Array} Returns `array`.
+ */
+function arrayCopy(source, array) {
+  var index = -1,
+      length = source.length;
+
+  array || (array = Array(length));
+  while (++index < length) {
+    array[index] = source[index];
+  }
+  return array;
+}
+
+module.exports = arrayCopy;

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._arraycopy/package.json
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._arraycopy/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "lodash._arraycopy",
+  "version": "3.0.0",
+  "description": "The modern build of lodash’s internal `arrayCopy` as a module.",
+  "homepage": "https://lodash.com/",
+  "icon": "https://lodash.com/icon.svg",
+  "license": "MIT",
+  "author": {
+    "name": "John-David Dalton",
+    "email": "john.david.dalton@gmail.com",
+    "url": "http://allyoucanleet.com/"
+  },
+  "contributors": [
+    {
+      "name": "John-David Dalton",
+      "email": "john.david.dalton@gmail.com",
+      "url": "http://allyoucanleet.com/"
+    },
+    {
+      "name": "Benjamin Tan",
+      "email": "demoneaux@gmail.com",
+      "url": "https://d10.github.io/"
+    },
+    {
+      "name": "Blaine Bublitz",
+      "email": "blaine@iceddev.com",
+      "url": "http://www.iceddev.com/"
+    },
+    {
+      "name": "Kit Cambridge",
+      "email": "github@kitcambridge.be",
+      "url": "http://kitcambridge.be/"
+    },
+    {
+      "name": "Mathias Bynens",
+      "email": "mathias@qiwi.be",
+      "url": "https://mathiasbynens.be/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lodash/lodash"
+  },
+  "scripts": {
+    "test": "echo \"See https://travis-ci.org/lodash/lodash-cli for testing details.\""
+  },
+  "bugs": {
+    "url": "https://github.com/lodash/lodash/issues"
+  },
+  "_id": "lodash._arraycopy@3.0.0",
+  "_shasum": "76e7b7c1f1fb92547374878a562ed06a3e50f6e1",
+  "_from": "lodash._arraycopy@>=3.0.0 <4.0.0",
+  "_npmVersion": "2.3.0",
+  "_nodeVersion": "0.10.35",
+  "_npmUser": {
+    "name": "jdalton",
+    "email": "john.david.dalton@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "jdalton",
+      "email": "john.david.dalton@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "76e7b7c1f1fb92547374878a562ed06a3e50f6e1",
+    "tarball": "http://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+}

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._basevalues/LICENSE.txt
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._basevalues/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js 1.7.0, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._basevalues/README.md
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._basevalues/README.md
@@ -1,0 +1,20 @@
+# lodash._basevalues v3.0.0
+
+The [modern build](https://github.com/lodash/lodash/wiki/Build-Differences) of [lodash’s](https://lodash.com/) internal `baseValues` exported as a [Node.js](http://nodejs.org/)/[io.js](https://iojs.org/) module.
+
+## Installation
+
+Using npm:
+
+```bash
+$ {sudo -H} npm i -g npm
+$ npm i --save lodash._basevalues
+```
+
+In Node.js/io.js:
+
+```js
+var baseValues = require('lodash._basevalues');
+```
+
+See the [package source](https://github.com/lodash/lodash/blob/3.0.0-npm-packages/lodash._basevalues) for more details.

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._basevalues/index.js
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._basevalues/index.js
@@ -1,0 +1,31 @@
+/**
+ * lodash 3.0.0 (Custom Build) <https://lodash.com/>
+ * Build: `lodash modern modularize exports="npm" -o ./`
+ * Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+ * Based on Underscore.js 1.7.0 <http://underscorejs.org/LICENSE>
+ * Copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ * Available under MIT license <https://lodash.com/license>
+ */
+
+/**
+ * The base implementation of `_.values` and `_.valuesIn` which creates an
+ * array of `object` property values corresponding to the property names
+ * returned by `keysFunc`.
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @param {Array} props The property names to get values for.
+ * @returns {Object} Returns the array of property values.
+ */
+function baseValues(object, props) {
+  var index = -1,
+      length = props.length,
+      result = Array(length);
+
+  while (++index < length) {
+    result[index] = object[props[index]];
+  }
+  return result;
+}
+
+module.exports = baseValues;

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._basevalues/package.json
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash._basevalues/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "lodash._basevalues",
+  "version": "3.0.0",
+  "description": "The modern build of lodash’s internal `baseValues` as a module.",
+  "homepage": "https://lodash.com/",
+  "icon": "https://lodash.com/icon.svg",
+  "license": "MIT",
+  "author": {
+    "name": "John-David Dalton",
+    "email": "john.david.dalton@gmail.com",
+    "url": "http://allyoucanleet.com/"
+  },
+  "contributors": [
+    {
+      "name": "John-David Dalton",
+      "email": "john.david.dalton@gmail.com",
+      "url": "http://allyoucanleet.com/"
+    },
+    {
+      "name": "Benjamin Tan",
+      "email": "demoneaux@gmail.com",
+      "url": "https://d10.github.io/"
+    },
+    {
+      "name": "Blaine Bublitz",
+      "email": "blaine@iceddev.com",
+      "url": "http://www.iceddev.com/"
+    },
+    {
+      "name": "Kit Cambridge",
+      "email": "github@kitcambridge.be",
+      "url": "http://kitcambridge.be/"
+    },
+    {
+      "name": "Mathias Bynens",
+      "email": "mathias@qiwi.be",
+      "url": "https://mathiasbynens.be/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lodash/lodash"
+  },
+  "scripts": {
+    "test": "echo \"See https://travis-ci.org/lodash/lodash-cli for testing details.\""
+  },
+  "bugs": {
+    "url": "https://github.com/lodash/lodash/issues"
+  },
+  "_id": "lodash._basevalues@3.0.0",
+  "_shasum": "5b775762802bde3d3297503e26300820fdf661b7",
+  "_from": "lodash._basevalues@>=3.0.0 <4.0.0",
+  "_npmVersion": "2.3.0",
+  "_nodeVersion": "0.10.35",
+  "_npmUser": {
+    "name": "jdalton",
+    "email": "john.david.dalton@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "jdalton",
+      "email": "john.david.dalton@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "5b775762802bde3d3297503e26300820fdf661b7",
+    "tarball": "http://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/LICENSE
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/LICENSE
@@ -1,0 +1,22 @@
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/README.md
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/README.md
@@ -1,0 +1,20 @@
+# lodash.keys v3.1.2
+
+The [modern build](https://github.com/lodash/lodash/wiki/Build-Differences) of [lodash’s](https://lodash.com/) `_.keys` exported as a [Node.js](http://nodejs.org/)/[io.js](https://iojs.org/) module.
+
+## Installation
+
+Using npm:
+
+```bash
+$ {sudo -H} npm i -g npm
+$ npm i --save lodash.keys
+```
+
+In Node.js/io.js:
+
+```js
+var keys = require('lodash.keys');
+```
+
+See the [documentation](https://lodash.com/docs#keys) or [package source](https://github.com/lodash/lodash/blob/3.1.2-npm-packages/lodash.keys) for more details.

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/index.js
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/index.js
@@ -1,0 +1,236 @@
+/**
+ * lodash 3.1.2 (Custom Build) <https://lodash.com/>
+ * Build: `lodash modern modularize exports="npm" -o ./`
+ * Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+ * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
+ * Copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ * Available under MIT license <https://lodash.com/license>
+ */
+var getNative = require('lodash._getnative'),
+    isArguments = require('lodash.isarguments'),
+    isArray = require('lodash.isarray');
+
+/** Used to detect unsigned integer values. */
+var reIsUint = /^\d+$/;
+
+/** Used for native method references. */
+var objectProto = Object.prototype;
+
+/** Used to check objects for own properties. */
+var hasOwnProperty = objectProto.hasOwnProperty;
+
+/* Native method references for those with the same name as other `lodash` methods. */
+var nativeKeys = getNative(Object, 'keys');
+
+/**
+ * Used as the [maximum length](http://ecma-international.org/ecma-262/6.0/#sec-number.max_safe_integer)
+ * of an array-like value.
+ */
+var MAX_SAFE_INTEGER = 9007199254740991;
+
+/**
+ * The base implementation of `_.property` without support for deep paths.
+ *
+ * @private
+ * @param {string} key The key of the property to get.
+ * @returns {Function} Returns the new function.
+ */
+function baseProperty(key) {
+  return function(object) {
+    return object == null ? undefined : object[key];
+  };
+}
+
+/**
+ * Gets the "length" property value of `object`.
+ *
+ * **Note:** This function is used to avoid a [JIT bug](https://bugs.webkit.org/show_bug.cgi?id=142792)
+ * that affects Safari on at least iOS 8.1-8.3 ARM64.
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @returns {*} Returns the "length" value.
+ */
+var getLength = baseProperty('length');
+
+/**
+ * Checks if `value` is array-like.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is array-like, else `false`.
+ */
+function isArrayLike(value) {
+  return value != null && isLength(getLength(value));
+}
+
+/**
+ * Checks if `value` is a valid array-like index.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @param {number} [length=MAX_SAFE_INTEGER] The upper bounds of a valid index.
+ * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
+ */
+function isIndex(value, length) {
+  value = (typeof value == 'number' || reIsUint.test(value)) ? +value : -1;
+  length = length == null ? MAX_SAFE_INTEGER : length;
+  return value > -1 && value % 1 == 0 && value < length;
+}
+
+/**
+ * Checks if `value` is a valid array-like length.
+ *
+ * **Note:** This function is based on [`ToLength`](http://ecma-international.org/ecma-262/6.0/#sec-tolength).
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a valid length, else `false`.
+ */
+function isLength(value) {
+  return typeof value == 'number' && value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER;
+}
+
+/**
+ * A fallback implementation of `Object.keys` which creates an array of the
+ * own enumerable property names of `object`.
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @returns {Array} Returns the array of property names.
+ */
+function shimKeys(object) {
+  var props = keysIn(object),
+      propsLength = props.length,
+      length = propsLength && object.length;
+
+  var allowIndexes = !!length && isLength(length) &&
+    (isArray(object) || isArguments(object));
+
+  var index = -1,
+      result = [];
+
+  while (++index < propsLength) {
+    var key = props[index];
+    if ((allowIndexes && isIndex(key, length)) || hasOwnProperty.call(object, key)) {
+      result.push(key);
+    }
+  }
+  return result;
+}
+
+/**
+ * Checks if `value` is the [language type](https://es5.github.io/#x8) of `Object`.
+ * (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is an object, else `false`.
+ * @example
+ *
+ * _.isObject({});
+ * // => true
+ *
+ * _.isObject([1, 2, 3]);
+ * // => true
+ *
+ * _.isObject(1);
+ * // => false
+ */
+function isObject(value) {
+  // Avoid a V8 JIT bug in Chrome 19-20.
+  // See https://code.google.com/p/v8/issues/detail?id=2291 for more details.
+  var type = typeof value;
+  return !!value && (type == 'object' || type == 'function');
+}
+
+/**
+ * Creates an array of the own enumerable property names of `object`.
+ *
+ * **Note:** Non-object values are coerced to objects. See the
+ * [ES spec](http://ecma-international.org/ecma-262/6.0/#sec-object.keys)
+ * for more details.
+ *
+ * @static
+ * @memberOf _
+ * @category Object
+ * @param {Object} object The object to query.
+ * @returns {Array} Returns the array of property names.
+ * @example
+ *
+ * function Foo() {
+ *   this.a = 1;
+ *   this.b = 2;
+ * }
+ *
+ * Foo.prototype.c = 3;
+ *
+ * _.keys(new Foo);
+ * // => ['a', 'b'] (iteration order is not guaranteed)
+ *
+ * _.keys('hi');
+ * // => ['0', '1']
+ */
+var keys = !nativeKeys ? shimKeys : function(object) {
+  var Ctor = object == null ? undefined : object.constructor;
+  if ((typeof Ctor == 'function' && Ctor.prototype === object) ||
+      (typeof object != 'function' && isArrayLike(object))) {
+    return shimKeys(object);
+  }
+  return isObject(object) ? nativeKeys(object) : [];
+};
+
+/**
+ * Creates an array of the own and inherited enumerable property names of `object`.
+ *
+ * **Note:** Non-object values are coerced to objects.
+ *
+ * @static
+ * @memberOf _
+ * @category Object
+ * @param {Object} object The object to query.
+ * @returns {Array} Returns the array of property names.
+ * @example
+ *
+ * function Foo() {
+ *   this.a = 1;
+ *   this.b = 2;
+ * }
+ *
+ * Foo.prototype.c = 3;
+ *
+ * _.keysIn(new Foo);
+ * // => ['a', 'b', 'c'] (iteration order is not guaranteed)
+ */
+function keysIn(object) {
+  if (object == null) {
+    return [];
+  }
+  if (!isObject(object)) {
+    object = Object(object);
+  }
+  var length = object.length;
+  length = (length && isLength(length) &&
+    (isArray(object) || isArguments(object)) && length) || 0;
+
+  var Ctor = object.constructor,
+      index = -1,
+      isProto = typeof Ctor == 'function' && Ctor.prototype === object,
+      result = Array(length),
+      skipIndexes = length > 0;
+
+  while (++index < length) {
+    result[index] = (index + '');
+  }
+  for (var key in object) {
+    if (!(skipIndexes && isIndex(key, length)) &&
+        !(key == 'constructor' && (isProto || !hasOwnProperty.call(object, key)))) {
+      result.push(key);
+    }
+  }
+  return result;
+}
+
+module.exports = keys;

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash._getnative/LICENSE
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash._getnative/LICENSE
@@ -1,0 +1,22 @@
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash._getnative/README.md
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash._getnative/README.md
@@ -1,0 +1,20 @@
+# lodash._getnative v3.9.1
+
+The [modern build](https://github.com/lodash/lodash/wiki/Build-Differences) of [lodash’s](https://lodash.com/) internal `getNative` exported as a [Node.js](http://nodejs.org/)/[io.js](https://iojs.org/) module.
+
+## Installation
+
+Using npm:
+
+```bash
+$ {sudo -H} npm i -g npm
+$ npm i --save lodash._getnative
+```
+
+In Node.js/io.js:
+
+```js
+var getNative = require('lodash._getnative');
+```
+
+See the [package source](https://github.com/lodash/lodash/blob/3.9.1-npm-packages/lodash._getnative) for more details.

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash._getnative/index.js
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash._getnative/index.js
@@ -1,0 +1,137 @@
+/**
+ * lodash 3.9.1 (Custom Build) <https://lodash.com/>
+ * Build: `lodash modern modularize exports="npm" -o ./`
+ * Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+ * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
+ * Copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ * Available under MIT license <https://lodash.com/license>
+ */
+
+/** `Object#toString` result references. */
+var funcTag = '[object Function]';
+
+/** Used to detect host constructors (Safari > 5). */
+var reIsHostCtor = /^\[object .+?Constructor\]$/;
+
+/**
+ * Checks if `value` is object-like.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
+ */
+function isObjectLike(value) {
+  return !!value && typeof value == 'object';
+}
+
+/** Used for native method references. */
+var objectProto = Object.prototype;
+
+/** Used to resolve the decompiled source of functions. */
+var fnToString = Function.prototype.toString;
+
+/** Used to check objects for own properties. */
+var hasOwnProperty = objectProto.hasOwnProperty;
+
+/**
+ * Used to resolve the [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+ * of values.
+ */
+var objToString = objectProto.toString;
+
+/** Used to detect if a method is native. */
+var reIsNative = RegExp('^' +
+  fnToString.call(hasOwnProperty).replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
+  .replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$'
+);
+
+/**
+ * Gets the native function at `key` of `object`.
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @param {string} key The key of the method to get.
+ * @returns {*} Returns the function if it's native, else `undefined`.
+ */
+function getNative(object, key) {
+  var value = object == null ? undefined : object[key];
+  return isNative(value) ? value : undefined;
+}
+
+/**
+ * Checks if `value` is classified as a `Function` object.
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is correctly classified, else `false`.
+ * @example
+ *
+ * _.isFunction(_);
+ * // => true
+ *
+ * _.isFunction(/abc/);
+ * // => false
+ */
+function isFunction(value) {
+  // The use of `Object#toString` avoids issues with the `typeof` operator
+  // in older versions of Chrome and Safari which return 'function' for regexes
+  // and Safari 8 equivalents which return 'object' for typed array constructors.
+  return isObject(value) && objToString.call(value) == funcTag;
+}
+
+/**
+ * Checks if `value` is the [language type](https://es5.github.io/#x8) of `Object`.
+ * (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is an object, else `false`.
+ * @example
+ *
+ * _.isObject({});
+ * // => true
+ *
+ * _.isObject([1, 2, 3]);
+ * // => true
+ *
+ * _.isObject(1);
+ * // => false
+ */
+function isObject(value) {
+  // Avoid a V8 JIT bug in Chrome 19-20.
+  // See https://code.google.com/p/v8/issues/detail?id=2291 for more details.
+  var type = typeof value;
+  return !!value && (type == 'object' || type == 'function');
+}
+
+/**
+ * Checks if `value` is a native function.
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a native function, else `false`.
+ * @example
+ *
+ * _.isNative(Array.prototype.push);
+ * // => true
+ *
+ * _.isNative(_);
+ * // => false
+ */
+function isNative(value) {
+  if (value == null) {
+    return false;
+  }
+  if (isFunction(value)) {
+    return reIsNative.test(fnToString.call(value));
+  }
+  return isObjectLike(value) && reIsHostCtor.test(value);
+}
+
+module.exports = getNative;

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash._getnative/package.json
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash._getnative/package.json
@@ -1,0 +1,84 @@
+{
+  "name": "lodash._getnative",
+  "version": "3.9.1",
+  "description": "The modern build of lodash’s internal `getNative` as a module.",
+  "homepage": "https://lodash.com/",
+  "icon": "https://lodash.com/icon.svg",
+  "license": "MIT",
+  "author": {
+    "name": "John-David Dalton",
+    "email": "john.david.dalton@gmail.com",
+    "url": "http://allyoucanleet.com/"
+  },
+  "contributors": [
+    {
+      "name": "John-David Dalton",
+      "email": "john.david.dalton@gmail.com",
+      "url": "http://allyoucanleet.com/"
+    },
+    {
+      "name": "Benjamin Tan",
+      "email": "demoneaux@gmail.com",
+      "url": "https://d10.github.io/"
+    },
+    {
+      "name": "Blaine Bublitz",
+      "email": "blaine@iceddev.com",
+      "url": "http://www.iceddev.com/"
+    },
+    {
+      "name": "Kit Cambridge",
+      "email": "github@kitcambridge.be",
+      "url": "http://kitcambridge.be/"
+    },
+    {
+      "name": "Mathias Bynens",
+      "email": "mathias@qiwi.be",
+      "url": "https://mathiasbynens.be/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lodash/lodash.git"
+  },
+  "scripts": {
+    "test": "echo \"See https://travis-ci.org/lodash/lodash-cli for testing details.\""
+  },
+  "bugs": {
+    "url": "https://github.com/lodash/lodash/issues"
+  },
+  "_id": "lodash._getnative@3.9.1",
+  "_shasum": "570bc7dede46d61cdcde687d65d3eecbaa3aaff5",
+  "_from": "lodash._getnative@>=3.0.0 <4.0.0",
+  "_npmVersion": "2.12.0",
+  "_nodeVersion": "0.12.5",
+  "_npmUser": {
+    "name": "jdalton",
+    "email": "john.david.dalton@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "jdalton",
+      "email": "john.david.dalton@gmail.com"
+    },
+    {
+      "name": "kitcambridge",
+      "email": "github@kitcambridge.be"
+    },
+    {
+      "name": "mathias",
+      "email": "mathias@qiwi.be"
+    },
+    {
+      "name": "phated",
+      "email": "blaine@iceddev.com"
+    }
+  ],
+  "dist": {
+    "shasum": "570bc7dede46d61cdcde687d65d3eecbaa3aaff5",
+    "tarball": "http://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarguments/LICENSE
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarguments/LICENSE
@@ -1,0 +1,22 @@
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarguments/README.md
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarguments/README.md
@@ -1,0 +1,20 @@
+# lodash.isarguments v3.0.4
+
+The [modern build](https://github.com/lodash/lodash/wiki/Build-Differences) of [lodash’s](https://lodash.com/) `_.isArguments` exported as a [Node.js](http://nodejs.org/)/[io.js](https://iojs.org/) module.
+
+## Installation
+
+Using npm:
+
+```bash
+$ {sudo -H} npm i -g npm
+$ npm i --save lodash.isarguments
+```
+
+In Node.js/io.js:
+
+```js
+var isArguments = require('lodash.isarguments');
+```
+
+See the [documentation](https://lodash.com/docs#isArguments) or [package source](https://github.com/lodash/lodash/blob/3.0.4-npm-packages/lodash.isarguments) for more details.

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarguments/index.js
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarguments/index.js
@@ -1,0 +1,106 @@
+/**
+ * lodash 3.0.4 (Custom Build) <https://lodash.com/>
+ * Build: `lodash modern modularize exports="npm" -o ./`
+ * Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+ * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
+ * Copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ * Available under MIT license <https://lodash.com/license>
+ */
+
+/**
+ * Checks if `value` is object-like.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
+ */
+function isObjectLike(value) {
+  return !!value && typeof value == 'object';
+}
+
+/** Used for native method references. */
+var objectProto = Object.prototype;
+
+/** Used to check objects for own properties. */
+var hasOwnProperty = objectProto.hasOwnProperty;
+
+/** Native method references. */
+var propertyIsEnumerable = objectProto.propertyIsEnumerable;
+
+/**
+ * Used as the [maximum length](http://ecma-international.org/ecma-262/6.0/#sec-number.max_safe_integer)
+ * of an array-like value.
+ */
+var MAX_SAFE_INTEGER = 9007199254740991;
+
+/**
+ * The base implementation of `_.property` without support for deep paths.
+ *
+ * @private
+ * @param {string} key The key of the property to get.
+ * @returns {Function} Returns the new function.
+ */
+function baseProperty(key) {
+  return function(object) {
+    return object == null ? undefined : object[key];
+  };
+}
+
+/**
+ * Gets the "length" property value of `object`.
+ *
+ * **Note:** This function is used to avoid a [JIT bug](https://bugs.webkit.org/show_bug.cgi?id=142792)
+ * that affects Safari on at least iOS 8.1-8.3 ARM64.
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @returns {*} Returns the "length" value.
+ */
+var getLength = baseProperty('length');
+
+/**
+ * Checks if `value` is array-like.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is array-like, else `false`.
+ */
+function isArrayLike(value) {
+  return value != null && isLength(getLength(value));
+}
+
+/**
+ * Checks if `value` is a valid array-like length.
+ *
+ * **Note:** This function is based on [`ToLength`](http://ecma-international.org/ecma-262/6.0/#sec-tolength).
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a valid length, else `false`.
+ */
+function isLength(value) {
+  return typeof value == 'number' && value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER;
+}
+
+/**
+ * Checks if `value` is classified as an `arguments` object.
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is correctly classified, else `false`.
+ * @example
+ *
+ * _.isArguments(function() { return arguments; }());
+ * // => true
+ *
+ * _.isArguments([1, 2, 3]);
+ * // => false
+ */
+function isArguments(value) {
+  return isObjectLike(value) && isArrayLike(value) &&
+    hasOwnProperty.call(value, 'callee') && !propertyIsEnumerable.call(value, 'callee');
+}
+
+module.exports = isArguments;

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarguments/package.json
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarguments/package.json
@@ -1,0 +1,94 @@
+{
+  "name": "lodash.isarguments",
+  "version": "3.0.4",
+  "description": "The modern build of lodash’s `_.isArguments` as a module.",
+  "homepage": "https://lodash.com/",
+  "icon": "https://lodash.com/icon.svg",
+  "license": "MIT",
+  "keywords": [
+    "lodash",
+    "lodash-modularized",
+    "stdlib",
+    "util"
+  ],
+  "author": {
+    "name": "John-David Dalton",
+    "email": "john.david.dalton@gmail.com",
+    "url": "http://allyoucanleet.com/"
+  },
+  "contributors": [
+    {
+      "name": "John-David Dalton",
+      "email": "john.david.dalton@gmail.com",
+      "url": "http://allyoucanleet.com/"
+    },
+    {
+      "name": "Benjamin Tan",
+      "email": "demoneaux@gmail.com",
+      "url": "https://d10.github.io/"
+    },
+    {
+      "name": "Blaine Bublitz",
+      "email": "blaine@iceddev.com",
+      "url": "http://www.iceddev.com/"
+    },
+    {
+      "name": "Kit Cambridge",
+      "email": "github@kitcambridge.be",
+      "url": "http://kitcambridge.be/"
+    },
+    {
+      "name": "Mathias Bynens",
+      "email": "mathias@qiwi.be",
+      "url": "https://mathiasbynens.be/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lodash/lodash.git"
+  },
+  "scripts": {
+    "test": "echo \"See https://travis-ci.org/lodash/lodash-cli for testing details.\""
+  },
+  "bugs": {
+    "url": "https://github.com/lodash/lodash/issues"
+  },
+  "_id": "lodash.isarguments@3.0.4",
+  "_shasum": "ebbb884c48d27366a44ea6fee57ed7b5a32a81e0",
+  "_from": "lodash.isarguments@>=3.0.0 <4.0.0",
+  "_npmVersion": "2.12.0",
+  "_nodeVersion": "0.12.5",
+  "_npmUser": {
+    "name": "jdalton",
+    "email": "john.david.dalton@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "jdalton",
+      "email": "john.david.dalton@gmail.com"
+    },
+    {
+      "name": "kitcambridge",
+      "email": "github@kitcambridge.be"
+    },
+    {
+      "name": "mathias",
+      "email": "mathias@qiwi.be"
+    },
+    {
+      "name": "phated",
+      "email": "blaine@iceddev.com"
+    },
+    {
+      "name": "d10",
+      "email": "demoneaux@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "ebbb884c48d27366a44ea6fee57ed7b5a32a81e0",
+    "tarball": "http://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarray/LICENSE
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarray/LICENSE
@@ -1,0 +1,22 @@
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarray/README.md
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarray/README.md
@@ -1,0 +1,20 @@
+# lodash.isarray v3.0.4
+
+The [modern build](https://github.com/lodash/lodash/wiki/Build-Differences) of [lodash’s](https://lodash.com/) `_.isArray` exported as a [Node.js](http://nodejs.org/)/[io.js](https://iojs.org/) module.
+
+## Installation
+
+Using npm:
+
+```bash
+$ {sudo -H} npm i -g npm
+$ npm i --save lodash.isarray
+```
+
+In Node.js/io.js:
+
+```js
+var isArray = require('lodash.isarray');
+```
+
+See the [documentation](https://lodash.com/docs#isArray) or [package source](https://github.com/lodash/lodash/blob/3.0.4-npm-packages/lodash.isarray) for more details.

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarray/index.js
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarray/index.js
@@ -1,0 +1,180 @@
+/**
+ * lodash 3.0.4 (Custom Build) <https://lodash.com/>
+ * Build: `lodash modern modularize exports="npm" -o ./`
+ * Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+ * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
+ * Copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ * Available under MIT license <https://lodash.com/license>
+ */
+
+/** `Object#toString` result references. */
+var arrayTag = '[object Array]',
+    funcTag = '[object Function]';
+
+/** Used to detect host constructors (Safari > 5). */
+var reIsHostCtor = /^\[object .+?Constructor\]$/;
+
+/**
+ * Checks if `value` is object-like.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
+ */
+function isObjectLike(value) {
+  return !!value && typeof value == 'object';
+}
+
+/** Used for native method references. */
+var objectProto = Object.prototype;
+
+/** Used to resolve the decompiled source of functions. */
+var fnToString = Function.prototype.toString;
+
+/** Used to check objects for own properties. */
+var hasOwnProperty = objectProto.hasOwnProperty;
+
+/**
+ * Used to resolve the [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+ * of values.
+ */
+var objToString = objectProto.toString;
+
+/** Used to detect if a method is native. */
+var reIsNative = RegExp('^' +
+  fnToString.call(hasOwnProperty).replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
+  .replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$'
+);
+
+/* Native method references for those with the same name as other `lodash` methods. */
+var nativeIsArray = getNative(Array, 'isArray');
+
+/**
+ * Used as the [maximum length](http://ecma-international.org/ecma-262/6.0/#sec-number.max_safe_integer)
+ * of an array-like value.
+ */
+var MAX_SAFE_INTEGER = 9007199254740991;
+
+/**
+ * Gets the native function at `key` of `object`.
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @param {string} key The key of the method to get.
+ * @returns {*} Returns the function if it's native, else `undefined`.
+ */
+function getNative(object, key) {
+  var value = object == null ? undefined : object[key];
+  return isNative(value) ? value : undefined;
+}
+
+/**
+ * Checks if `value` is a valid array-like length.
+ *
+ * **Note:** This function is based on [`ToLength`](http://ecma-international.org/ecma-262/6.0/#sec-tolength).
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a valid length, else `false`.
+ */
+function isLength(value) {
+  return typeof value == 'number' && value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER;
+}
+
+/**
+ * Checks if `value` is classified as an `Array` object.
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is correctly classified, else `false`.
+ * @example
+ *
+ * _.isArray([1, 2, 3]);
+ * // => true
+ *
+ * _.isArray(function() { return arguments; }());
+ * // => false
+ */
+var isArray = nativeIsArray || function(value) {
+  return isObjectLike(value) && isLength(value.length) && objToString.call(value) == arrayTag;
+};
+
+/**
+ * Checks if `value` is classified as a `Function` object.
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is correctly classified, else `false`.
+ * @example
+ *
+ * _.isFunction(_);
+ * // => true
+ *
+ * _.isFunction(/abc/);
+ * // => false
+ */
+function isFunction(value) {
+  // The use of `Object#toString` avoids issues with the `typeof` operator
+  // in older versions of Chrome and Safari which return 'function' for regexes
+  // and Safari 8 equivalents which return 'object' for typed array constructors.
+  return isObject(value) && objToString.call(value) == funcTag;
+}
+
+/**
+ * Checks if `value` is the [language type](https://es5.github.io/#x8) of `Object`.
+ * (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is an object, else `false`.
+ * @example
+ *
+ * _.isObject({});
+ * // => true
+ *
+ * _.isObject([1, 2, 3]);
+ * // => true
+ *
+ * _.isObject(1);
+ * // => false
+ */
+function isObject(value) {
+  // Avoid a V8 JIT bug in Chrome 19-20.
+  // See https://code.google.com/p/v8/issues/detail?id=2291 for more details.
+  var type = typeof value;
+  return !!value && (type == 'object' || type == 'function');
+}
+
+/**
+ * Checks if `value` is a native function.
+ *
+ * @static
+ * @memberOf _
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a native function, else `false`.
+ * @example
+ *
+ * _.isNative(Array.prototype.push);
+ * // => true
+ *
+ * _.isNative(_);
+ * // => false
+ */
+function isNative(value) {
+  if (value == null) {
+    return false;
+  }
+  if (isFunction(value)) {
+    return reIsNative.test(fnToString.call(value));
+  }
+  return isObjectLike(value) && reIsHostCtor.test(value);
+}
+
+module.exports = isArray;

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarray/package.json
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/node_modules/lodash.isarray/package.json
@@ -1,0 +1,94 @@
+{
+  "name": "lodash.isarray",
+  "version": "3.0.4",
+  "description": "The modern build of lodash’s `_.isArray` as a module.",
+  "homepage": "https://lodash.com/",
+  "icon": "https://lodash.com/icon.svg",
+  "license": "MIT",
+  "keywords": [
+    "lodash",
+    "lodash-modularized",
+    "stdlib",
+    "util"
+  ],
+  "author": {
+    "name": "John-David Dalton",
+    "email": "john.david.dalton@gmail.com",
+    "url": "http://allyoucanleet.com/"
+  },
+  "contributors": [
+    {
+      "name": "John-David Dalton",
+      "email": "john.david.dalton@gmail.com",
+      "url": "http://allyoucanleet.com/"
+    },
+    {
+      "name": "Benjamin Tan",
+      "email": "demoneaux@gmail.com",
+      "url": "https://d10.github.io/"
+    },
+    {
+      "name": "Blaine Bublitz",
+      "email": "blaine@iceddev.com",
+      "url": "http://www.iceddev.com/"
+    },
+    {
+      "name": "Kit Cambridge",
+      "email": "github@kitcambridge.be",
+      "url": "http://kitcambridge.be/"
+    },
+    {
+      "name": "Mathias Bynens",
+      "email": "mathias@qiwi.be",
+      "url": "https://mathiasbynens.be/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lodash/lodash.git"
+  },
+  "scripts": {
+    "test": "echo \"See https://travis-ci.org/lodash/lodash-cli for testing details.\""
+  },
+  "bugs": {
+    "url": "https://github.com/lodash/lodash/issues"
+  },
+  "_id": "lodash.isarray@3.0.4",
+  "_shasum": "79e4eb88c36a8122af86f844aa9bcd851b5fbb55",
+  "_from": "lodash.isarray@>=3.0.0 <4.0.0",
+  "_npmVersion": "2.12.0",
+  "_nodeVersion": "0.12.5",
+  "_npmUser": {
+    "name": "jdalton",
+    "email": "john.david.dalton@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "jdalton",
+      "email": "john.david.dalton@gmail.com"
+    },
+    {
+      "name": "kitcambridge",
+      "email": "github@kitcambridge.be"
+    },
+    {
+      "name": "mathias",
+      "email": "mathias@qiwi.be"
+    },
+    {
+      "name": "phated",
+      "email": "blaine@iceddev.com"
+    },
+    {
+      "name": "d10",
+      "email": "demoneaux@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "79e4eb88c36a8122af86f844aa9bcd851b5fbb55",
+    "tarball": "http://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/package.json
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/node_modules/lodash.keys/package.json
@@ -1,0 +1,99 @@
+{
+  "name": "lodash.keys",
+  "version": "3.1.2",
+  "description": "The modern build of lodash’s `_.keys` as a module.",
+  "homepage": "https://lodash.com/",
+  "icon": "https://lodash.com/icon.svg",
+  "license": "MIT",
+  "keywords": [
+    "lodash",
+    "lodash-modularized",
+    "stdlib",
+    "util"
+  ],
+  "author": {
+    "name": "John-David Dalton",
+    "email": "john.david.dalton@gmail.com",
+    "url": "http://allyoucanleet.com/"
+  },
+  "contributors": [
+    {
+      "name": "John-David Dalton",
+      "email": "john.david.dalton@gmail.com",
+      "url": "http://allyoucanleet.com/"
+    },
+    {
+      "name": "Benjamin Tan",
+      "email": "demoneaux@gmail.com",
+      "url": "https://d10.github.io/"
+    },
+    {
+      "name": "Blaine Bublitz",
+      "email": "blaine@iceddev.com",
+      "url": "http://www.iceddev.com/"
+    },
+    {
+      "name": "Kit Cambridge",
+      "email": "github@kitcambridge.be",
+      "url": "http://kitcambridge.be/"
+    },
+    {
+      "name": "Mathias Bynens",
+      "email": "mathias@qiwi.be",
+      "url": "https://mathiasbynens.be/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lodash/lodash.git"
+  },
+  "scripts": {
+    "test": "echo \"See https://travis-ci.org/lodash/lodash-cli for testing details.\""
+  },
+  "dependencies": {
+    "lodash._getnative": "^3.0.0",
+    "lodash.isarguments": "^3.0.0",
+    "lodash.isarray": "^3.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/lodash/lodash/issues"
+  },
+  "_id": "lodash.keys@3.1.2",
+  "_shasum": "4dbc0472b156be50a0b286855d1bd0b0c656098a",
+  "_from": "lodash.keys@>=3.0.0 <4.0.0",
+  "_npmVersion": "2.12.0",
+  "_nodeVersion": "0.12.5",
+  "_npmUser": {
+    "name": "jdalton",
+    "email": "john.david.dalton@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "jdalton",
+      "email": "john.david.dalton@gmail.com"
+    },
+    {
+      "name": "kitcambridge",
+      "email": "github@kitcambridge.be"
+    },
+    {
+      "name": "mathias",
+      "email": "mathias@qiwi.be"
+    },
+    {
+      "name": "phated",
+      "email": "blaine@iceddev.com"
+    },
+    {
+      "name": "d10",
+      "email": "demoneaux@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "4dbc0472b156be50a0b286855d1bd0b0c656098a",
+    "tarball": "http://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/node_modules/intercept-stdout/node_modules/lodash.toarray/package.json
+++ b/node_modules/intercept-stdout/node_modules/lodash.toarray/package.json
@@ -1,0 +1,98 @@
+{
+  "name": "lodash.toarray",
+  "version": "3.0.2",
+  "description": "The modern build of lodash’s `_.toArray` as a module.",
+  "homepage": "https://lodash.com/",
+  "icon": "https://lodash.com/icon.svg",
+  "license": "MIT",
+  "keywords": [
+    "lodash",
+    "lodash-modularized",
+    "stdlib",
+    "util"
+  ],
+  "author": {
+    "name": "John-David Dalton",
+    "email": "john.david.dalton@gmail.com",
+    "url": "http://allyoucanleet.com/"
+  },
+  "contributors": [
+    {
+      "name": "John-David Dalton",
+      "email": "john.david.dalton@gmail.com",
+      "url": "http://allyoucanleet.com/"
+    },
+    {
+      "name": "Benjamin Tan",
+      "email": "demoneaux@gmail.com",
+      "url": "https://d10.github.io/"
+    },
+    {
+      "name": "Blaine Bublitz",
+      "email": "blaine@iceddev.com",
+      "url": "http://www.iceddev.com/"
+    },
+    {
+      "name": "Kit Cambridge",
+      "email": "github@kitcambridge.be",
+      "url": "http://kitcambridge.be/"
+    },
+    {
+      "name": "Mathias Bynens",
+      "email": "mathias@qiwi.be",
+      "url": "https://mathiasbynens.be/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lodash/lodash.git"
+  },
+  "scripts": {
+    "test": "echo \"See https://travis-ci.org/lodash/lodash-cli for testing details.\""
+  },
+  "dependencies": {
+    "lodash._arraycopy": "^3.0.0",
+    "lodash._basevalues": "^3.0.0",
+    "lodash.keys": "^3.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/lodash/lodash/issues"
+  },
+  "_id": "lodash.toarray@3.0.2",
+  "_shasum": "2b204f0fa4f51c285c6f00c81d1cea5a23041179",
+  "_from": "lodash.toarray@>=3.0.0 <4.0.0",
+  "_npmVersion": "2.10.0",
+  "_nodeVersion": "0.12.3",
+  "_npmUser": {
+    "name": "jdalton",
+    "email": "john.david.dalton@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "jdalton",
+      "email": "john.david.dalton@gmail.com"
+    },
+    {
+      "name": "kitcambridge",
+      "email": "github@kitcambridge.be"
+    },
+    {
+      "name": "mathias",
+      "email": "mathias@qiwi.be"
+    },
+    {
+      "name": "phated",
+      "email": "blaine@iceddev.com"
+    },
+    {
+      "name": "d10",
+      "email": "demoneaux@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "2b204f0fa4f51c285c6f00c81d1cea5a23041179",
+    "tarball": "http://registry.npmjs.org/lodash.toarray/-/lodash.toarray-3.0.2.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-3.0.2.tgz"
+}

--- a/node_modules/intercept-stdout/package.json
+++ b/node_modules/intercept-stdout/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "intercept-stdout",
+  "version": "0.1.2",
+  "description": "Hooking Node.js stdout",
+  "main": "intercept-stdout.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sfarthin/intercept-stdout"
+  },
+  "keywords": [
+    "stdout",
+    "stderr"
+  ],
+  "author": {
+    "name": "Steven Farthing"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/sfarthin/intercept-stdout/issues"
+  },
+  "dependencies": {
+    "lodash.toarray": "^3.0.0"
+  },
+  "devDependencies": {
+    "chai": "~1.8.1",
+    "mocha": "~1.17.1"
+  },
+  "gitHead": "6a1338d630f422424c16fe1fb23f9934b80ee769",
+  "homepage": "https://github.com/sfarthin/intercept-stdout",
+  "_id": "intercept-stdout@0.1.2",
+  "_shasum": "126abf1fae6c509a428a98c61a631559042ae9fd",
+  "_from": "intercept-stdout@*",
+  "_npmVersion": "1.4.28",
+  "_npmUser": {
+    "name": "stevefar",
+    "email": "me@stevefar.com"
+  },
+  "maintainers": [
+    {
+      "name": "stevefar",
+      "email": "me@stevefar.com"
+    }
+  ],
+  "dist": {
+    "shasum": "126abf1fae6c509a428a98c61a631559042ae9fd",
+    "tarball": "http://registry.npmjs.org/intercept-stdout/-/intercept-stdout-0.1.2.tgz"
+  },
+  "_resolved": "https://registry.npmjs.org/intercept-stdout/-/intercept-stdout-0.1.2.tgz"
+}

--- a/node_modules/intercept-stdout/test/intercept.js
+++ b/node_modules/intercept-stdout/test/intercept.js
@@ -1,0 +1,178 @@
+var expect = require("chai").expect,
+    Intercept = require("../intercept-stdout.js"),
+    os = require('os');
+
+describe("intercept-stdout", function() {
+
+    describe('when one interceptor are specified', function() {
+
+        it("should capture stdout when initialized and not when it is unhooked", function() {
+
+            // Lets set up our intercept
+            var captured_text = "";
+            var unhook = Intercept(function(txt) {
+                captured_text += txt;
+            });
+
+            // Lets try each of these pieces of text
+            var arr = ["capture-this!", "日本語", "-k21.12-0k-ª–m-md1∆º¡∆ªº"];
+            arr.forEach(function(txt) {
+
+                // Make sure we don't see the captured text yet.
+                expect(captured_text).to.not.have.string(txt);
+
+                // send to stdout.
+                console.log(txt);
+
+                // Make sure we have the captured text.
+                expect(captured_text).to.have.string(txt);
+
+            });
+
+            unhook();
+            captured_text = "";
+
+            arr = ["capture-this!", "日本語", "-k21.12-0k-ª–m-md1∆º¡∆ªº"];
+            arr.forEach(function(txt) {
+
+                // send to stdout.
+                console.log(txt);
+
+                // Make sure we have not captured text.
+                expect(captured_text).to.be.equal("");
+
+            });
+
+        });
+
+        it("should modify output if callback returns a string", function() {
+
+            var captured = [];
+            var unhook = Intercept(function(txt) {
+                var mod = modified[captured.length];
+                captured.push(mod);
+                return mod;
+            });
+
+            var arr = ["capture-this!", "日本語", "-k21.12-0k-ª–m-md1∆º¡∆ªº"];
+            var modified = ["print-this!", "asdf", ""];
+
+            arr.forEach(function(txt) {
+                // send to stdout.
+                console.log(txt);
+                // make sure captured doesn't contain the original text
+                expect(captured).to.not.contain(txt);
+            });
+
+            expect(captured).to.eql(modified);
+
+            unhook();
+
+        });
+
+        it("should do the same for console.error", function() {
+
+            var captured = [];
+            var unhook = Intercept(function(txt) {
+                var mod = modified[captured.length];
+                captured.push(mod);
+                return mod;
+            });
+
+            var arr = ["capture-this!", "日本語", "-k21.12-0k-ª–m-md1∆º¡∆ªº"];
+            var modified = ["print-this!", "asdf", ""];
+
+            arr.forEach(function(txt) {
+                console.error(txt);
+            });
+
+            expect(captured).to.eql(modified);
+
+            unhook();
+
+        });
+    });
+
+    describe('when two interceptors are specified', function() {
+
+        var outputs = [];
+        var errors = [];
+        var unhook;
+
+        var expectedOutputs = ["capture-this!", "日本語", "-k21.12-0k-ª–m-md1∆º¡∆ªº"];
+        var expectedErrors = ["errors here!", "日本語 < huh?", "-k21.12-0k-ª–m-md1∆º¡∆ªº <-- that's some wierd stuff"];
+
+        before(function() {
+        	unhook = Intercept(
+        		function(txt) {
+        			outputs.push(txt);
+        		},
+        		function(txt) {
+        			errors.push(txt);
+        		} );
+
+        	expectedOutputs.forEach(function(txt) {
+        		console.log(txt);
+        	});
+
+        	expectedErrors.forEach(function(txt) {
+        		console.error(txt);
+        	});
+
+        });
+
+        it("stdout is passed thru first interceptor", function(done) {
+
+        	expectedOutputs.forEach(function(txt) {
+        		expect(outputs).to.contain(txt + os.EOL);
+        	});
+
+        	expectedErrors.forEach(function(txt) {
+        		expect(outputs).to.not.contain(txt + os.EOL);
+        	});
+
+        	done();
+        });
+
+        it("stderr is passed thru second interceptor", function(done) {
+
+        	expectedErrors.forEach(function(txt) {
+        		expect(errors).to.contain(txt + os.EOL);
+        	});
+
+        	expectedOutputs.forEach(function(txt) {
+        		expect(errors).to.not.contain(txt + os.EOL);
+        	});
+
+        	done();
+        });
+
+        describe("after the interceptors are unhooked", function() {
+
+        	before(function() {
+        		unhook();
+        		outputs = [];
+        		errors = [];
+
+        		expectedOutputs.forEach(function(txt) {
+        			console.log(txt);
+        		});
+
+        		expectedErrors.forEach(function(txt) {
+        			console.error(txt);
+        		});
+        	});
+
+        	it("stdout is no longer passed thru first interceptor", function(done) {
+
+        	  expect(outputs.length).to.eql(0);
+        	  expect(errors.length).to.eql(0);
+
+        		done();
+        	});
+
+        });
+
+      });
+
+});

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "minimist": "*"
   },
   "devDependencies": {
+    "intercept-stdout": "*",
     "jshint": "*",
     "tv4": "*"
   }

--- a/tasks/jshint-ejs.js
+++ b/tasks/jshint-ejs.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+var async = require("async");
+var ejs = require("ejs");
+var fs = require("fs");
+var intercept = require("intercept-stdout");
+var jshint = require("jshint").JSHINT;
+
+var jshint_options = {
+  "-W032": true,  // Don't warn about extra semicolons
+  "-W085": true,  // Don't warn about use of with
+};
+
+function find_real_line(error, source) {
+  var lineStart = 0;
+  for (var line = 1; line < error.line; line++) {
+    lineStart = source.indexOf("\n", lineStart + 1);
+    if (lineStart == -1) {
+      throw new Error("Could not find line " + error.line);
+    }
+  }
+
+  var errorLocation = lineStart + error.character;
+  var lineMarkerLocation = source.lastIndexOf("__line = ", errorLocation);
+  var semicolonLocation = source.indexOf(";", lineMarkerLocation);
+  var lineNumberText = source.substring(lineMarkerLocation + "__line = ".length,
+    semicolonLocation);
+  var templateLineNumber = parseInt(lineNumberText);
+
+  if (isNaN(templateLineNumber) || semicolonLocation == -1 ||
+    lineMarkerLocation == -1) {
+    throw new Error("Could not find line number marker");
+  }
+  return templateLineNumber;
+}
+
+var exit_code = 0;
+
+async.eachSeries(process.argv.slice(2),
+  function(arg, done) {
+    var contents = fs.readFileSync(arg, {encoding: "utf-8"});
+    var source = "";
+
+    // ejs doesn't provide an easy way to get the uncompiled source of a
+    // template. However, it does print this with console.log() when the debug
+    // option is set. Thus, we temporarily divert standard output to capture
+    // the function source.
+    var unhook_intercept = intercept(function(text) {
+      source += text;
+      return "";
+    });
+    ejs.compile(contents, {filename: arg, debug: true});
+    unhook_intercept();
+
+    jshint(source, jshint_options);
+    if (jshint.errors.length > 0) {
+      exit_code = 1;
+    }
+
+    for (var i = 0; i < jshint.errors.length; i++) {
+      var error = jshint.errors[i];
+      if (error === null) {
+        continue;
+      }
+      var templateLine = find_real_line(error, source);
+      var message = arg + ": line " + templateLine + ", " + error.reason;
+      console.error(message);
+    }
+
+    done();
+  },
+  function(error) {
+    if (error) {
+      console.error("Error encountered: " + error);
+      process.exit(1);
+    }
+    process.exit(exit_code);
+  }
+);

--- a/tasks/pre-commit
+++ b/tasks/pre-commit
@@ -27,5 +27,6 @@ fi
 ruby -c Gemfile >/dev/null
 ruby -c config/environment.rb >/dev/null
 ruby -c tasks/elasticsearch.rake >/dev/null
-node_modules/jshint/bin/jshint app.js app/helpers.js app/routes.js config/config.js.example tasks/inspectors.js tasks/validate-json.js
+node_modules/jshint/bin/jshint app.js app/helpers.js app/routes.js config/config.js.example tasks/inspectors.js tasks/validate-json.js tasks/jshint-ejs.js
 tasks/validate-json.js
+tasks/jshint-ejs.js views/layout/footer.html views/layout/header.html views/partials/search.html views/index.html views/report.html views/reports.html


### PR DESCRIPTION
This adds a script to the pre-commit hook and Travis CI build to check all ejs templates by running JSHint on the output from ejs. When I get a chance I may spin this off into a separate NPM module.