### PR TITLE
Move HTTP port to config.yaml for consistency

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,11 +1,15 @@
-// this is an Express app
+var config = require("./config/config");
 var express = require('express');
 var app = express();
 
 // environment and port
 var env = process.env.NODE_ENV || 'development';
-var port = parseInt(process.argv[2], 10);
-if (isNaN(port)) port = 3000;
+var port;
+if (config && config.http && config.http.port) {
+  port = config.http.port;
+} else {
+  port = 3000;
+}
 
 // app middleware/settings
 app.engine('.html', require('ejs').__express);

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -7,6 +7,10 @@ elasticsearch:
   host: 127.0.0.1
   port: 9200
 
+# http server exposed by the app
+http:
+  port: 3000
+
 # automatically ping search engines after generating the sitemap
 sitemap:
   ping_google: false

--- a/fabfile.py
+++ b/fabfile.py
@@ -20,9 +20,6 @@ current_path = "%s/current" % home
 # how many old releases to be kept at deploy-time
 keep = 3
 
-# port in the storm
-port = 3000
-
 # can be run only as part of deploy
 def checkout():
   run('git clone -q -b %s %s %s' % (branch, repo, version_path))
@@ -51,13 +48,13 @@ def cleanup():
 ## can be run on their own
 
 def start():
-  run("cd %s && NODE_ENV=%s forever -l %s/forever.log -a start app.js -p %i" % (current_path, environment, logs, port))
+  run("cd %s && NODE_ENV=%s forever -l %s/forever.log -a start app.js" % (current_path, environment, logs))
 
 def stop():
-  run("forever stop app.js -p %i" % port)
+  run("forever stop app.js")
 
 def restart():
-  run("forever restart app.js -p %i" % port)
+  run("forever restart app.js")
 
 def deploy():
   execute(checkout)


### PR DESCRIPTION
I figure if we put the port number in the config file, rather than on the command line, that will make higher-level tools easier to write, since we can change HTTP port number, ElasticSearch server information, and future options in the same place.