### PR TITLE
Pass 'production' to npm install

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -29,7 +29,7 @@ def links():
 
 # install node (and ruby?) dependencies
 def dependencies():
-  run("cd %s && npm install" % version_path)
+  run("cd %s && NODE_ENV=%s npm install" % (version_path, environment))
 
 # TODO: why cp instead of ln?
 def make_current():


### PR DESCRIPTION
This will skip installing development dependencies.