### PR TITLE
Remove method-override

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,6 @@ app.engine('.html', require('ejs').__express);
 app.enable('trust proxy')
   .use(require('body-parser').json())
   .use(require('body-parser').urlencoded({extended: false}))
-  .use(require('method-override')())
   .use(function(req,res,next){
     res.locals.req = req;
     next();

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1560,17 +1560,6 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
-    "method-override": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.10.tgz",
-      "integrity": "sha1-49r41d7hDdLc59SuiNYrvud0drQ=",
-      "requires": {
-        "debug": "2.6.9",
-        "methods": "~1.1.2",
-        "parseurl": "~1.3.2",
-        "vary": "~1.1.2"
-      }
-    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "glob": "^7.0.5",
     "http-aws-es": "^6.0.0",
     "js-yaml": "^3.13.1",
-    "method-override": "^2.3.5",
     "minimist": "^1.2.0",
     "moment": "^2.20.1",
     "numeral": "^2.0.1",


### PR DESCRIPTION
In favor of #216, this removes the method-override package and middleware from the project. The middleware by default allows replacing the HTTP method verb with the value of the `X-HTTP-Method-Override` header, but this isn't needed, as the browser is our only client, and there's no AJAX to use this feature.